### PR TITLE
Don't write to disk in dev mode

### DIFF
--- a/kits/react/webpack.config.js
+++ b/kits/react/webpack.config.js
@@ -12,7 +12,6 @@ module.exports = {
   devServer: {
     historyApiFallback: true,
     contentBase: path.join(__dirname, 'dist'),
-    writeToDisk: true,
   },
   resolve: {
     extensions: ['.js', '.jsx'],

--- a/kits/vanilla/webpack.config.js
+++ b/kits/vanilla/webpack.config.js
@@ -11,7 +11,6 @@ module.exports = {
   },
   devServer: {
     contentBase: path.join(__dirname, 'dist'),
-    writeToDisk: true,
   },
   module: {
     rules: [


### PR DESCRIPTION
Často se stává, že někdo při vývoji upravuje omylem soubory uvnitř složky `dist`, což by se dělat nemělo.

Tenhle PR se snaží o to, aby složka při vývoji vůbec nevznikala a tím pádem nemátla.

Co si o tom prosím myslí @lrolecek. Nenaruší to nějak tvé lekce?