### PR TITLE
Output to dist folder

### DIFF
--- a/kits/react/webpack.config.js
+++ b/kits/react/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
   entry: './src/index.jsx',
   devtool: 'eval-source-map',
   output: {
-    path: path.join(__dirname, 'public'),
+    path: path.join(__dirname, 'dist'),
     filename: 'bundle.js',
     assetModuleFilename: 'img/[name]-[hash:6].[ext]',
   },

--- a/kits/vanilla/webpack.config.js
+++ b/kits/vanilla/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
   entry: './src/index.js',
   devtool: 'eval-source-map',
   output: {
-    path: path.join(__dirname, 'public'),
+    path: path.join(__dirname, 'dist'),
     filename: 'bundle.js',
     assetModuleFilename: 'img/[name]-[hash:6].[ext]'
   },


### PR DESCRIPTION
- Opravuje kolizi public složek pro dva účely.
- Zpětně více kompatibilní s předchozími běhy a materiály.
- Opravuje gitignorování distribuční složky.